### PR TITLE
Fix 21 events missing IDs to enable API validation

### DIFF
--- a/data/events.json
+++ b/data/events.json
@@ -63414,7 +63414,8 @@
     "contact_phone": null,
     "website_url": null,
     "image_url": null,
-    "recurring_pattern": null
+    "recurring_pattern": null,
+    "id": "0e8a8476-b0f6-4649-bf86-544b95f8d990"
   },
   {
     "title": "Terence Keel at Harvard Book Store",
@@ -63441,7 +63442,8 @@
     "contact_phone": null,
     "website_url": null,
     "image_url": null,
-    "recurring_pattern": null
+    "recurring_pattern": null,
+    "id": "5455b06c-9f62-47ca-a7a8-39f67ed3d927"
   },
   {
     "title": "Anthony M. Amore at Harvard Book Store",
@@ -63468,7 +63470,8 @@
     "contact_phone": null,
     "website_url": null,
     "image_url": null,
-    "recurring_pattern": null
+    "recurring_pattern": null,
+    "id": "cd179457-d5b5-4d5c-baa9-3de8bbd11906"
   },
   {
     "title": "Winter Warehouse Sale Frequent Buyer Shopping",
@@ -63495,7 +63498,8 @@
     "contact_phone": null,
     "website_url": null,
     "image_url": null,
-    "recurring_pattern": null
+    "recurring_pattern": null,
+    "id": "686b9db6-5d02-4c41-8ad4-4fc1fcabade8"
   },
   {
     "title": "Janet Lewis Saidi and Alexandra Socarides at Harvard Book Store",
@@ -63522,7 +63526,8 @@
     "contact_phone": null,
     "website_url": null,
     "image_url": null,
-    "recurring_pattern": null
+    "recurring_pattern": null,
+    "id": "6665cc38-30a0-4c82-a0b8-ac2097a68d1f"
   },
   {
     "title": "Winter Warehouse Sale Day 1",
@@ -63549,7 +63554,8 @@
     "contact_phone": null,
     "website_url": null,
     "image_url": null,
-    "recurring_pattern": null
+    "recurring_pattern": null,
+    "id": "78df36f9-1673-4cc6-b289-b7e340a35af1"
   },
   {
     "title": "Winter Warehouse Sale Last Day",
@@ -63576,7 +63582,8 @@
     "contact_phone": null,
     "website_url": null,
     "image_url": null,
-    "recurring_pattern": null
+    "recurring_pattern": null,
+    "id": "fc7ff5ec-bb33-4be7-aaed-20e295f8f1d9"
   },
   {
     "title": "Tracy K. Smith at Harvard Book Store",
@@ -63603,7 +63610,8 @@
     "contact_phone": null,
     "website_url": null,
     "image_url": null,
-    "recurring_pattern": null
+    "recurring_pattern": null,
+    "id": "dbc4f253-9dd0-4a59-88c3-c4537b576cb8"
   },
   {
     "title": "Scott Kerman with Michael Dukakis at The Brattle Theatre",
@@ -63630,7 +63638,8 @@
     "contact_phone": null,
     "website_url": null,
     "image_url": null,
-    "recurring_pattern": null
+    "recurring_pattern": null,
+    "id": "26ca5cd1-0552-43d2-b043-62f76d196a01"
   },
   {
     "title": "John Fabian Witt at Harvard Book Store",
@@ -63657,7 +63666,8 @@
     "contact_phone": null,
     "website_url": null,
     "image_url": null,
-    "recurring_pattern": null
+    "recurring_pattern": null,
+    "id": "d0b3a9d7-7854-4dee-afd7-6015056ab0e9"
   },
   {
     "title": "The Easy Winners Deluxe Holiday Edition at Epic Ballroom!",
@@ -63684,7 +63694,8 @@
     "contact_phone": null,
     "website_url": null,
     "image_url": null,
-    "recurring_pattern": null
+    "recurring_pattern": null,
+    "id": "11779015-5ada-447f-9500-4549820e4e11"
   },
   {
     "title": "Swing Boot Camp \u2013 Dec 7",
@@ -63711,7 +63722,8 @@
     "contact_phone": null,
     "website_url": null,
     "image_url": null,
-    "recurring_pattern": null
+    "recurring_pattern": null,
+    "id": "9a5226dc-8e51-4518-ab3a-3f6e750ab8fd"
   },
   {
     "title": "The Whozit/Whatzit All-Star Band at Epic Ballroom!",
@@ -63738,7 +63750,8 @@
     "contact_phone": null,
     "website_url": null,
     "image_url": null,
-    "recurring_pattern": null
+    "recurring_pattern": null,
+    "id": "b7fde026-c59d-43e6-a858-7e65bf4b47da"
   },
   {
     "title": "Somerville Museum - Tavern Talk",
@@ -63765,7 +63778,8 @@
     "contact_phone": null,
     "website_url": null,
     "image_url": "https://imagedelivery.net/i1GtTC2HMEIvh05dUN1Tag/ced86f24-a89d-40d5-7796-011fa3716b00/600x450",
-    "recurring_pattern": null
+    "recurring_pattern": null,
+    "id": "3e92aa23-2790-4551-a2a6-c6d1db44d60b"
   },
   {
     "title": "Astronomy on Tap",
@@ -63792,7 +63806,8 @@
     "contact_phone": null,
     "website_url": null,
     "image_url": "https://imagedelivery.net/i1GtTC2HMEIvh05dUN1Tag/21af49ab-a467-4cf4-a5be-151fb6630800/600x450",
-    "recurring_pattern": null
+    "recurring_pattern": null,
+    "id": "78002a90-2e58-4a71-8d62-0eb66e1150ee"
   },
   {
     "title": "Aeronaut's Holiday Market at The Union Square Jingle",
@@ -63819,7 +63834,8 @@
     "contact_phone": null,
     "website_url": null,
     "image_url": "https://imagedelivery.net/i1GtTC2HMEIvh05dUN1Tag/37f5e8a3-79ca-4b24-4858-9fbe1b5f6a00/600x450",
-    "recurring_pattern": null
+    "recurring_pattern": null,
+    "id": "66b76ec3-e0a4-4241-afe2-3a1f506e4d3a"
   },
   {
     "title": "Wednesday Tile Club",
@@ -63846,7 +63862,8 @@
     "contact_phone": null,
     "website_url": null,
     "image_url": "https://imagedelivery.net/i1GtTC2HMEIvh05dUN1Tag/b341760e-5391-4163-cb44-214119b36600/600x450",
-    "recurring_pattern": null
+    "recurring_pattern": null,
+    "id": "5cc76017-f93b-4a0e-bb5c-7fdb5c30dc72"
   },
   {
     "title": "Meat the Need: A Meat Raffle to Benefit The Elizabeth Peabody House",
@@ -63873,7 +63890,8 @@
     "contact_phone": null,
     "website_url": null,
     "image_url": "https://imagedelivery.net/i1GtTC2HMEIvh05dUN1Tag/73ee8048-f3f2-450b-2d2b-34205e8e9300/600x450",
-    "recurring_pattern": null
+    "recurring_pattern": null,
+    "id": "08f416c4-a01d-4742-a06d-ab87df522ccb"
   },
   {
     "title": "Flagons & Dragons: A D&D Brewery Takeover with Danger Wizard",
@@ -63900,7 +63918,8 @@
     "contact_phone": null,
     "website_url": null,
     "image_url": "https://imagedelivery.net/i1GtTC2HMEIvh05dUN1Tag/9291b84f-7075-481c-e429-ca8e3b744e00/600x450",
-    "recurring_pattern": null
+    "recurring_pattern": null,
+    "id": "75f66807-056a-420f-9976-14ec6125a869"
   },
   {
     "title": "Gingerbread House Decorating",
@@ -63927,7 +63946,8 @@
     "contact_phone": null,
     "website_url": null,
     "image_url": "https://imagedelivery.net/i1GtTC2HMEIvh05dUN1Tag/21b6e93d-c51f-4fbc-0ff7-c59c6213ef00/600x450",
-    "recurring_pattern": null
+    "recurring_pattern": null,
+    "id": "6f5f39e5-00eb-4378-a042-56fe06d5018a"
   },
   {
     "title": "Holiday Drag Night",
@@ -63954,6 +63974,7 @@
     "contact_phone": null,
     "website_url": null,
     "image_url": "https://imagedelivery.net/i1GtTC2HMEIvh05dUN1Tag/7f39e809-8f91-4564-1bc5-9a33a3dc2400/600x450",
-    "recurring_pattern": null
+    "recurring_pattern": null,
+    "id": "19d0245b-7c5b-4c3c-be99-5e5034267b8e"
   }
 ]


### PR DESCRIPTION
Events without IDs were causing Pydantic model validation to fail, which prevented Railway from serving any events (returning empty list).